### PR TITLE
Add splat for private_route_table_id output

### DIFF
--- a/interface.tf
+++ b/interface.tf
@@ -100,7 +100,7 @@ output "public_route_table_id" {
 }
 
 output "private_route_table_id" {
-  value = "${aws_route_table.private.id}"
+  value = "${aws_route_table.private.*.id}"
 }
 
 output "default_security_group_id" {


### PR DESCRIPTION
Calling `terraform plan` result in the following error:

> Warning: output "private_route_table_id": must use splat syntax to access aws_route_table.private attribute "id", because it has "count" set; use aws_route_table.private.*.id to obtain a list of the attributes across all instances
 
Examining the resource show that the count field is been used

```
resource "aws_route_table" "private" {
  count  = "${length(var.private_subnets)}"
  vpc_id = "${aws_vpc.environment.id}"

  tags {
    Name = "${var.environment}-private"
  }
} 
```

Applying this change resolves the warning. 

