### PR TITLE
Make configuration v0.12 compatible

### DIFF
--- a/interface.tf
+++ b/interface.tf
@@ -39,16 +39,13 @@ variable "instance_type" {
   description = "The instance type to launch "
 }
 
-variable "vpc_id" {
-  description = "The VPC ID to launch in"
-}
-
 variable "bastion_instance_type" {
   default     = "t2.micro"
   description = "The bastion host instance type."
 }
 
 variable "bastion_ami" {
+  type = "map"
   default = {
     "us-east-1" = "ami-f652979b"
     "us-west-1" = "ami-7c4b331c"

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "aws_vpc" "environment" {
   enable_dns_hostnames = "${var.enable_dns_hostnames}"
   enable_dns_support   = "${var.enable_dns_support}"
 
-  tags {
+  tags = {
     Name = "${var.environment}"
   }
 }
@@ -11,7 +11,7 @@ resource "aws_vpc" "environment" {
 resource "aws_internet_gateway" "environment" {
   vpc_id = "${aws_vpc.environment.id}"
 
-  tags {
+  tags = {
     Name = "${var.environment}-igw"
   }
 }
@@ -19,7 +19,7 @@ resource "aws_internet_gateway" "environment" {
 resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.environment.id}"
 
-  tags {
+  tags = {
     Name = "${var.environment}-public"
   }
 }
@@ -28,7 +28,7 @@ resource "aws_route_table" "private" {
   count  = "${length(var.private_subnets)}"
   vpc_id = "${aws_vpc.environment.id}"
 
-  tags {
+  tags = {
     Name = "${var.environment}-private"
   }
 }
@@ -51,7 +51,7 @@ resource "aws_subnet" "public" {
   cidr_block              = "${var.public_subnets[count.index]}"
   map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
 
-  tags {
+  tags = {
     Name = "${var.environment}-public-${count.index}"
   }
 
@@ -63,7 +63,7 @@ resource "aws_subnet" "private" {
   cidr_block              = "${var.private_subnets[count.index]}"
   map_public_ip_on_launch = "false"
 
-  tags {
+  tags = {
     Name = "${var.environment}-private-${count.index}"
   }
 
@@ -121,7 +121,7 @@ resource "aws_security_group" "bastion" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.environment}-bastion-sg"
   }
 }
@@ -135,7 +135,7 @@ resource "aws_instance" "bastion" {
   subnet_id                   = "${aws_subnet.public.*.id[0]}"
   associate_public_ip_address = true
 
-  tags {
+  tags = {
     Name = "${var.environment}-bastion"
   }
 }


### PR DESCRIPTION
These changes (intentionally) keep the configuration still 0.11 compatible.

I reckon when 0.12 final is out the configuration can be upgraded using the [upgrade guide](https://www.terraform.io/upgrade-guides/0-12.html) and `0.12upgrade` command.